### PR TITLE
Add popup navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,19 @@
         .toast.error { background: linear-gradient(135deg, #dc2626, #b91c1c); border-color: #f87171; }
         .toast.levelup { background: linear-gradient(135deg, var(--xp-color), #a855f7); border-color: var(--gold-light); font-size: 1.2rem; padding: 1rem 2rem; }
         @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+        .nav-button { position: fixed; top: 20px; right: 20px; z-index: 1000; background: var(--gold-primary); color: #fff; border: none; border-radius: 50%; width: 48px; height: 48px; font-size: 1.5rem; cursor: pointer; box-shadow: 0 2px 5px rgba(0,0,0,0.3); }
+        .nav-popup { position: fixed; top: 70px; right: 20px; background: var(--dark-stone); border: 1px solid var(--border-gold); border-radius: 0.5rem; box-shadow: 0 5px 15px rgba(0,0,0,0.5); display: none; flex-direction: column; z-index: 1000; }
+        .nav-popup a { color: var(--text-light); padding: 0.5rem 1rem; text-decoration: none; white-space: nowrap; }
+        .nav-popup a:hover { background: var(--dark-marble); }
+        .nav-popup.active { display: flex; }
     </style>
 </head>
 <body>
+    <button class="nav-button" id="navButton">☰</button>
+    <div class="nav-popup" id="navPopup">
+        <a href="index.html">Accueil</a>
+        <a href="page2.html">Page 2</a>
+    </div>
     <div class="imperium-ui">
         <div class="imperium-body">
             <main class="main-content">
@@ -694,6 +704,16 @@
         loadGameState();
         setInterval(gameTick, 1000);
         setInterval(saveGameState, 30000);
+        const navButton = document.getElementById('navButton');
+        const navPopup = document.getElementById('navPopup');
+        navButton.addEventListener('click', () => {
+            navPopup.classList.toggle('active');
+        });
+        document.addEventListener('click', (e) => {
+            if (!navPopup.contains(e.target) && e.target !== navButton) {
+                navPopup.classList.remove('active');
+            }
+        });
     });
     </script>
 </body>

--- a/page2.html
+++ b/page2.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 2 - IMPERIUM</title>
+    <style>
+        :root {
+            --gold-primary: #d97706;
+            --dark-stone: #1e293b;
+            --dark-bg: #0f172a;
+            --text-light: #e2e8f0;
+            --dark-marble: #334155;
+            --border-gold: rgba(217, 119, 6, 0.3);
+        }
+        body {
+            font-family: 'Times New Roman', serif;
+            background: linear-gradient(135deg, var(--dark-bg) 0%, var(--dark-stone) 100%);
+            color: var(--text-light);
+            margin: 0;
+        }
+        .content { padding: 2rem; }
+        .nav-button { position: fixed; top: 20px; right: 20px; z-index: 1000; background: var(--gold-primary); color: #fff; border: none; border-radius: 50%; width: 48px; height: 48px; font-size: 1.5rem; cursor: pointer; box-shadow: 0 2px 5px rgba(0,0,0,0.3); }
+        .nav-popup { position: fixed; top: 70px; right: 20px; background: var(--dark-stone); border: 1px solid var(--border-gold); border-radius: 0.5rem; box-shadow: 0 5px 15px rgba(0,0,0,0.5); display: none; flex-direction: column; z-index: 1000; }
+        .nav-popup a { color: var(--text-light); padding: 0.5rem 1rem; text-decoration: none; white-space: nowrap; }
+        .nav-popup a:hover { background: var(--dark-marble); }
+        .nav-popup.active { display: flex; }
+    </style>
+</head>
+<body>
+    <button class="nav-button" id="navButton">☰</button>
+    <div class="nav-popup" id="navPopup">
+        <a href="index.html">Accueil</a>
+        <a href="page2.html">Page 2</a>
+    </div>
+    <div class="content">
+        <h1>Page 2</h1>
+        <p>Contenu de démonstration.</p>
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const navButton = document.getElementById('navButton');
+            const navPopup = document.getElementById('navPopup');
+            navButton.addEventListener('click', () => {
+                navPopup.classList.toggle('active');
+            });
+            document.addEventListener('click', (e) => {
+                if (!navPopup.contains(e.target) && e.target !== navButton) {
+                    navPopup.classList.remove('active');
+                }
+            });
+        });
+    </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Add fixed navigation button and popup menu to main page
- Include JavaScript to toggle navigation menu visibility
- Provide secondary page to demonstrate cross-page navigation

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b3540d10832bbbb23eba1676fef9