### PR TITLE
Supprime les boutons retour et centralise la navigation

### DIFF
--- a/Simulateur.html
+++ b/Simulateur.html
@@ -237,7 +237,6 @@
                 </div>
                 <div id="view-simulator" class="view-container">
                     <div class="top-bar">
-                        <button class="small-btn" onclick="backToCity()">Retour</button>
                         <h2 class="view-title" style="margin: 0;">⚔️ IMPERIUM - Simulateur de Combat V18 ⚔️</h2>
                         <div id="resources-display" class="resources-display"></div>
                     </div>
@@ -884,10 +883,6 @@
     function openSimulator() {
         showView('view-simulator');
     }
-    function backToCity() {
-        showView('city-view');
-    }
-
     // ===============================================================
     // MOTEUR DE SIMULATION DE COMBAT V18
     // ===============================================================

--- a/index.html
+++ b/index.html
@@ -235,7 +235,6 @@
                 </div>
                 <div id="view-simulator" class="view-container">
                     <div class="top-bar">
-                        <button class="small-btn" onclick="backToCity()">Retour</button>
                         <h2 class="view-title" style="margin: 0;">⚔️ IMPERIUM - Simulateur de Combat V18 ⚔️</h2>
                         <div id="resources-display" class="resources-display"></div>
                     </div>
@@ -887,17 +886,6 @@
     </script>
 
     <script>
-    function showView(id) {
-        document.querySelectorAll('.view-container').forEach(v => v.classList.remove('active'));
-        document.getElementById(id).classList.add('active');
-    }
-    function openSimulator() {
-        showView('view-simulator');
-    }
-    function backToCity() {
-        showView('city-view');
-    }
-
     // ===============================================================
     // MOTEUR DE SIMULATION DE COMBAT V18
     // ===============================================================


### PR DESCRIPTION
## Résumé
- Retire les boutons "Retour" des vues de simulation pour utiliser uniquement le menu de navigation popup.
- Nettoie l'ancien code de navigation dans `index.html`.

## Tests
- `npm test` *(échec attendu : aucun script de test)*

------
https://chatgpt.com/codex/tasks/task_e_6895bb30e7d4832b9a19f1194270846f