### PR TITLE
Hide inactive modal overlay to re-enable start button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -45,8 +45,31 @@ body {
 .small-btn:hover { transform: translateY(-2px); filter: brightness(1.1); }
 
 /* --- Modals --- */
-.modal-container { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 1000; display: flex; justify-content: center; align-items: center; pointer-events: none; }
-.modal-container.active { pointer-events: all; }
+/*
+ * Par défaut, le conteneur de modale couvrait toute la page
+ * avec `display: flex`. Même avec `pointer-events: none`,
+ * certains navigateurs bloquaient les clics sur les éléments
+ * en dessous (comme "Commencez à Jouer").
+ * Nous le rendons complètement invisible tant qu'il n'est pas actif
+ * afin de laisser passer les interactions.
+ */
+.modal-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    pointer-events: none;
+}
+
+.modal-container.active {
+    display: flex;
+    pointer-events: all;
+}
 .modal-backdrop { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(15, 23, 42, 0.8); backdrop-filter: blur(5px); opacity: 0; transition: opacity 0.3s ease; }
 .modal-container.active .modal-backdrop { opacity: 1; }
 .modal-content { background: linear-gradient(135deg, var(--dark-stone), var(--dark-bg)); border: 2px solid var(--gold-primary); border-radius: 1rem; box-shadow: 0 10px 30px rgba(0,0,0,0.5); width: 90%; max-width: 600px; z-index: 1001; transform: scale(0.9) translateY(20px); opacity: 0; transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94); display: flex; flex-direction: column; max-height: 90vh; }


### PR DESCRIPTION
## Summary
- Prevent the global modal overlay from blocking clicks by hiding the container when inactive

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689626620c58832bb8b75badbe3bb633